### PR TITLE
Readme trophy view updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 📫 How to reach me:dirambora12@gmail.com,&nbsp;[Twitter](https://mobile.twitter.com/diram_b), [LinkedIn](https://www.linkedin.com/in/diram-b-guyo-8bb9b1174/)
 
 <br><br>
-
+[![trophy](https://github-profile-trophy.vercel.app/?username=dirambora&margin-w=8)](https://github.com/ryo-ma/github-profile-trophy)
 <!--
 [![My GitHub Stats](https://github-readme-stats.vercel.app/api/?username=dirambora&count_private=true&theme=tokyonight&showicons=true)]()
 [![My GitHub Language Stats](https://github-readme-stats.vercel.app/api/top-langs/?username=dirambora&langs_count=5&theme=tokyonight)]()
@@ -24,9 +24,3 @@
 ![](https://github-readme-streak-stats.herokuapp.com/?user=dirambora&theme=light&hide_border=false)<br/>
 ![](https://github-readme-stats.vercel.app/api/top-langs/?username=dirambora&theme=light&hide_border=false&include_all_commits=true&count_private=true&layout=compact)
 
-
-<br>
-[![trophy](https://github-profile-trophy.vercel.app/?username=dirambora&margin-w=8)](https://github.com/ryo-ma/github-profile-trophy)
-
-
-<br>


### PR DESCRIPTION
Before it was showing link at place of trophy in readme, Now it's correct  